### PR TITLE
Fix teste json

### DIFF
--- a/bibgrafo/grafo_matriz_adj_dir.py
+++ b/bibgrafo/grafo_matriz_adj_dir.py
@@ -155,7 +155,7 @@ class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
         Returns:
             Um valor booleano que indica se o vértice existe no grafo.
         """
-        return self.get_vertice(rotulo) is not None
+        return rotulo in [v.rotulo for v in self.vertices]
 
     def indice_do_vertice(self, v: Vertice):
         """

--- a/grafo_json_test.py
+++ b/grafo_json_test.py
@@ -8,9 +8,9 @@ class GrafoJSONTest(unittest.TestCase):
     def setUp(self):
         self.g_l = GrafoListaAdjacenciaDirecionado()
         self.g_m = GrafoMatrizAdjacenciaDirecionado()
-        for i in range(5):
-            self.g_l.adiciona_vertice(chr(ord('A') + i))
-            self.g_m.adiciona_vertice(chr(ord('A') + i))
+        for v in ('A', 'B', 'C', 'D', 'E'):
+            self.g_l.adiciona_vertice(v)
+            self.g_m.adiciona_vertice(v)
         for v1 in range(len(self.g_l.vertices)):
             for v2 in range(v1 + 1, len(self.g_l.vertices)):
                 self.g_l.adiciona_aresta(chr(ord('a') + (v1)) + str(v2),


### PR DESCRIPTION
- Fix da nomenclatura de lista de adjacência para o teste do módulo de `GrafoJSON`
- Fix da função `existe_rotulo_vertice` na Matriz de Adjacência direcionada