### PR TITLE
Herança das Listas de Adj refactor + Implementação completa do padrão single dispatch

### DIFF
--- a/bibgrafo/grafo.py
+++ b/bibgrafo/grafo.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from bibgrafo.aresta import Aresta
 from bibgrafo.vertice import Vertice
-from multipledispatch import dispatch
+from functools import singledispatchmethod
 
 
 class GrafoIF(ABC):
@@ -61,7 +61,7 @@ class GrafoIF(ABC):
         """
         pass
 
-    @dispatch(str)
+    @singledispatchmethod
     @abstractmethod
     def adiciona_vertice(self, rotulo: str):
         """
@@ -73,9 +73,9 @@ class GrafoIF(ABC):
         """
         pass
 
-    @dispatch(Vertice)
+    @adiciona_vertice.register
     @abstractmethod
-    def adiciona_vertice(self, v: Vertice):
+    def _(self, v: Vertice):
         """
         Adiciona um vértice no Grafo caso o vértice seja válido e não exista outro vértice com o mesmo nome
         Args:
@@ -97,7 +97,7 @@ class GrafoIF(ABC):
         """
         pass
 
-    @dispatch(Aresta)
+    @singledispatchmethod
     @abstractmethod
     def adiciona_aresta(self, a: Aresta):
         """
@@ -111,9 +111,9 @@ class GrafoIF(ABC):
         """
         pass
 
-    @dispatch(str, str, str, int)
+    @adiciona_aresta.register
     @abstractmethod
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str, peso: int = 1):
+    def _(self, rotulo: str, v1: str, v2: str, peso: int = 1):
         """
         Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome
         Args:
@@ -125,23 +125,6 @@ class GrafoIF(ABC):
             True se a aresta foi adicionada com sucesso
         Raises:
             ArestaInvalidaError se a aresta passada como parâmetro não puder ser adicionada
-        """
-        pass
-
-    @dispatch(str, str, str)
-    @abstractmethod
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str):
-        """
-        Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome.
-        O peso atribuído à aresta será 1.
-        Args:
-            rotulo: O rótulo da aresta a ser adicionada.
-            v1: O primeiro vértice da aresta.
-            v2: O segundo vértice da aresta.
-        Returns:
-            True se a aresta foi adicionada com sucesso.
-        Raises:
-            ArestaInvalidaError se a aresta passada como parâmetro não puder ser adicionada.
         """
         pass
 

--- a/bibgrafo/grafo_lista_adj_dir.py
+++ b/bibgrafo/grafo_lista_adj_dir.py
@@ -2,7 +2,7 @@ from bibgrafo.grafo import GrafoIF
 from bibgrafo.aresta import ArestaDirecionada
 from bibgrafo.vertice import Vertice
 from bibgrafo.grafo_errors import *
-from multipledispatch import dispatch
+from functools import singledispatchmethod
 from copy import deepcopy
 
 
@@ -127,7 +127,7 @@ class GrafoListaAdjacenciaDirecionado(GrafoIF):
             if self._vertices[i].rotulo == rotulo:
                 return self._vertices[i]
 
-    @dispatch(str)
+    @singledispatchmethod
     def adiciona_vertice(self, rotulo: str):
         """
         Adiciona um vértice no Grafo caso o vértice seja válido e não exista outro vértice com o mesmo nome
@@ -141,8 +141,8 @@ class GrafoListaAdjacenciaDirecionado(GrafoIF):
         else:
             raise VerticeInvalidoError('O rótulo de vértice ' + rotulo + ' já existe no grafo')
 
-    @dispatch(Vertice)
-    def adiciona_vertice(self, v: Vertice):
+    @adiciona_vertice.register
+    def _(self, v: Vertice):
         """
         Adiciona um vértice no Grafo caso o vértice seja válido e não exista outro vértice com o mesmo nome
         Args:
@@ -209,7 +209,7 @@ class GrafoListaAdjacenciaDirecionado(GrafoIF):
             return True
         return False
 
-    @dispatch(ArestaDirecionada, namespace={})
+    @singledispatchmethod
     def adiciona_aresta(self, a: ArestaDirecionada):
         """
         Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome.
@@ -230,8 +230,8 @@ class GrafoListaAdjacenciaDirecionado(GrafoIF):
             raise ArestaInvalidaError('A aresta ' + str(a) + ' é inválida')
         return True
 
-    @dispatch(str, str, str, int)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str, peso: int = 1):
+    @adiciona_aresta.register
+    def _(self, rotulo: str, v1: str, v2: str, peso: int = 1):
         """
         Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome
         Args:
@@ -245,23 +245,6 @@ class GrafoListaAdjacenciaDirecionado(GrafoIF):
             ArestaInvalidaError se a aresta passada como parâmetro não puder ser adicionada
         """
         a = ArestaDirecionada(rotulo, self.get_vertice(v1), self.get_vertice(v2), peso)
-        return self.adiciona_aresta(a)
-
-    @dispatch(str, str, str)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str):
-        """
-        Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome.
-        O peso atribuído à aresta será 1.
-        Args:
-            rotulo: O rótulo da aresta a ser adicionada.
-            v1: O primeiro vértice da aresta.
-            v2: O segundo vértice da aresta.
-        Returns:
-            True se a aresta foi adicionada com sucesso.
-        Raises:
-            ArestaInvalidaError se a aresta passada como parâmetro não puder ser adicionada.
-        """
-        a = ArestaDirecionada(rotulo, self.get_vertice(v1), self.get_vertice(v2), 1)
         return self.adiciona_aresta(a)
 
     def remove_aresta(self, r: str):

--- a/bibgrafo/grafo_lista_adj_nao_dir.py
+++ b/bibgrafo/grafo_lista_adj_nao_dir.py
@@ -1,9 +1,7 @@
 from bibgrafo.grafo_lista_adj_dir import GrafoListaAdjacenciaDirecionado
 from bibgrafo.aresta import Aresta
-from bibgrafo.vertice import Vertice
 from bibgrafo.grafo_errors import *
-from multipledispatch import dispatch
-from copy import deepcopy
+from functools import singledispatchmethod
 
 
 class GrafoListaAdjacenciaNaoDirecionado(GrafoListaAdjacenciaDirecionado):
@@ -35,7 +33,7 @@ class GrafoListaAdjacenciaNaoDirecionado(GrafoListaAdjacenciaDirecionado):
             return True
         return False
 
-    @dispatch(Aresta)
+    @singledispatchmethod
     def adiciona_aresta(self, a: Aresta):
         """
         Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome.
@@ -56,8 +54,8 @@ class GrafoListaAdjacenciaNaoDirecionado(GrafoListaAdjacenciaDirecionado):
             raise ArestaInvalidaError('A aresta ' + str(a) + ' é inválida')
         return True
 
-    @dispatch(str, str, str, int)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str, peso: int = 1):
+    @adiciona_aresta.register
+    def _(self, rotulo: str, v1: str, v2: str, peso: int = 1):
         """
         Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome
         Args:
@@ -71,23 +69,6 @@ class GrafoListaAdjacenciaNaoDirecionado(GrafoListaAdjacenciaDirecionado):
             ArestaInvalidaError se a aresta passada como parâmetro não puder ser adicionada
         """
         a = Aresta(rotulo, self.get_vertice(v1), self.get_vertice(v2), peso)
-        return self.adiciona_aresta(a)
-
-    @dispatch(str, str, str)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str):
-        """
-        Adiciona uma aresta no Grafo caso a aresta seja válida e não exista outra aresta com o mesmo nome.
-        O peso atribuído à aresta será 1.
-        Args:
-            rotulo: O rótulo da aresta a ser adicionada.
-            v1: O primeiro vértice da aresta.
-            v2: O segundo vértice da aresta.
-        Returns:
-            True se a aresta foi adicionada com sucesso.
-        Raises:
-            ArestaInvalidaError se a aresta passada como parâmetro não puder ser adicionada.
-        """
-        a = Aresta(rotulo, self.get_vertice(v1), self.get_vertice(v2), 1)
         return self.adiciona_aresta(a)
 
     def __eq__(self, other):

--- a/bibgrafo/grafo_matriz_adj_dir.py
+++ b/bibgrafo/grafo_matriz_adj_dir.py
@@ -2,7 +2,7 @@ from bibgrafo.grafo import GrafoIF
 from bibgrafo.aresta import ArestaDirecionada
 from bibgrafo.grafo_errors import *
 from bibgrafo.vertice import Vertice
-from multipledispatch import dispatch
+from functools import singledispatchmethod
 from copy import deepcopy
 
 class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
@@ -168,7 +168,7 @@ class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
         """
         return self._vertices.index(v)
 
-    @dispatch(str)
+    @singledispatchmethod
     def adiciona_vertice(self, rotulo: str):
         """
         Inclui um vértice no grafo a partir de um rotulo. É criado um objeto do tipo Vertice com o rotulo inserido.
@@ -193,8 +193,8 @@ class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
         else:
             raise VerticeInvalidoError('O vértice ' + rotulo + ' é inválido')
 
-    @dispatch(Vertice)
-    def adiciona_vertice(self, v: Vertice):
+    @adiciona_vertice.register
+    def _(self, v: Vertice):
         """
         Inclui um vértice no grafo se ele estiver no formato correto.
         Args:
@@ -273,7 +273,7 @@ class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
                 return True
         return False
 
-    @dispatch(ArestaDirecionada)
+    @singledispatchmethod
     def adiciona_aresta(self, aresta: ArestaDirecionada):
         """
         Adiciona uma aresta ao grafo.
@@ -294,8 +294,8 @@ class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
 
         return True
 
-    @dispatch(str, str, str, int)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str, peso=1):
+    @adiciona_aresta.register
+    def _(self, rotulo: str, v1: str, v2: str, peso=1):
         """
         Adiciona uma aresta ao grafo.
         Args:
@@ -307,21 +307,6 @@ class GrafoMatrizAdjacenciaDirecionado(GrafoIF):
             ArestaInvalidaError: caso a aresta não estiver em um formato válido.
         """
         a = ArestaDirecionada(rotulo, self.get_vertice(v1), self.get_vertice(v2), peso)
-        return self.adiciona_aresta(a)
-
-    @dispatch(str, str, str)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str):
-        """
-        Adiciona uma aresta ao grafo.
-        Args:
-            rotulo: O rótulo da aresta
-            v1: O primeiro vértice da aresta
-            v2: O segundo vértice da aresta
-        Raises:
-            ArestaInvalidaError: caso a aresta não estiver em um formato válido
-        """
-
-        a = ArestaDirecionada(rotulo, self.get_vertice(v1), self.get_vertice(v2), 1)
         return self.adiciona_aresta(a)
 
     def remove_aresta(self, r: str, v1: str = None, v2: str = None):

--- a/bibgrafo/grafo_matriz_adj_nao_dir.py
+++ b/bibgrafo/grafo_matriz_adj_nao_dir.py
@@ -2,7 +2,7 @@ from bibgrafo.grafo_matriz_adj_dir import GrafoMatrizAdjacenciaDirecionado
 from bibgrafo.aresta import Aresta
 from bibgrafo.vertice import Vertice
 from bibgrafo.grafo_errors import *
-from multipledispatch import dispatch
+from functools import singledispatchmethod
 from copy import deepcopy
 
 
@@ -129,7 +129,7 @@ class GrafoMatrizAdjacenciaNaoDirecionado(GrafoMatrizAdjacenciaDirecionado):
                 if i != j and self._matriz[i][j] != self._matriz[j][i]:
                     raise MatrizInvalidaError('A matriz não representa uma matriz de grafo não direcionado')
 
-    @dispatch(str)
+    @singledispatchmethod
     def adiciona_vertice(self, rotulo: str):
         """
         Inclui um vértice no grafo se ele estiver no formato correto.
@@ -155,8 +155,8 @@ class GrafoMatrizAdjacenciaNaoDirecionado(GrafoMatrizAdjacenciaDirecionado):
         else:
             raise VerticeInvalidoError('O vértice ' + rotulo + ' é inválido.')
 
-    @dispatch(Vertice)
-    def adiciona_vertice(self, v: Vertice):
+    @adiciona_vertice.register
+    def _(self, v: Vertice):
         """
         Inclui um vértice no grafo se ele estiver no formato correto.
         Args:
@@ -224,7 +224,7 @@ class GrafoMatrizAdjacenciaNaoDirecionado(GrafoMatrizAdjacenciaDirecionado):
             return True
         return False
 
-    @dispatch(Aresta)
+    @singledispatchmethod
     def adiciona_aresta(self, a: Aresta):
         """
         Adiciona uma aresta ao grafo
@@ -246,8 +246,8 @@ class GrafoMatrizAdjacenciaNaoDirecionado(GrafoMatrizAdjacenciaDirecionado):
 
         return True
 
-    @dispatch(str, str, str, int)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str, peso=1):
+    @adiciona_aresta.register
+    def _(self, rotulo: str, v1: str, v2: str, peso=1):
         """
         Adiciona uma aresta ao grafo.
         Args:
@@ -259,22 +259,6 @@ class GrafoMatrizAdjacenciaNaoDirecionado(GrafoMatrizAdjacenciaDirecionado):
             ArestaInvalidaError: caso a aresta não estiver em um formato válido
         """
         a = Aresta(rotulo, self.get_vertice(v1), self.get_vertice(v2), peso)
-        return self.adiciona_aresta(a)
-
-    @dispatch(str, str, str)
-    def adiciona_aresta(self, rotulo: str, v1: str, v2: str):
-        """
-        Adiciona uma aresta ao grafo.
-        Args:
-            rotulo: O rótulo da aresta
-            v1: O primeiro vértice da aresta
-            v2: O segundo vértice da aresta
-        Raises:
-            ArestaInvalidaError: caso a aresta não estiver em um formato válido
-        """
-
-        # Quando o peso não é informado, atribui-se peso 1
-        a = Aresta(rotulo, self.get_vertice(v1), self.get_vertice(v2), 1)
         return self.adiciona_aresta(a)
 
     def remove_aresta(self, r: str, v1=None, v2=None):

--- a/grafo_lista_adj_dir_test.py
+++ b/grafo_lista_adj_dir_test.py
@@ -81,9 +81,9 @@ class TestGrafo(unittest.TestCase):
             self.assertTrue(self.g_p.adiciona_aresta('b1', '', 'C'))
         with self.assertRaises(VerticeInvalidoError):
             self.assertTrue(self.g_p.adiciona_aresta('b1', 'A', 'C'))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('')
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('aa-bb')
         with self.assertRaises(VerticeInvalidoError):
             self.g_p.adiciona_aresta('x', 'J', 'V')

--- a/grafo_lista_adj_nao_dir_test.py
+++ b/grafo_lista_adj_nao_dir_test.py
@@ -84,9 +84,9 @@ class TestGrafo(unittest.TestCase):
             self.assertTrue(self.g_p.adiciona_aresta('b1', '', 'C'))
         with self.assertRaises(VerticeInvalidoError):
             self.assertTrue(self.g_p.adiciona_aresta('b1', 'A', 'C'))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('')
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('aa-bb')
         with self.assertRaises(VerticeInvalidoError):
             self.g_p.adiciona_aresta('x', 'J', 'V')

--- a/grafo_matriz_adj_dir_test.py
+++ b/grafo_matriz_adj_dir_test.py
@@ -85,9 +85,9 @@ class TestGrafo(unittest.TestCase):
             self.assertTrue(self.g_p.adiciona_aresta('b1', '', 'C'))
         with self.assertRaises(VerticeInvalidoError):
             self.assertTrue(self.g_p.adiciona_aresta('b1', 'A', 'C'))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('')
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('aa-bb')
         with self.assertRaises(VerticeInvalidoError):
             self.g_p.adiciona_aresta('x', 'J', 'V')

--- a/grafo_matriz_adj_nao_dir_test.py
+++ b/grafo_matriz_adj_nao_dir_test.py
@@ -65,9 +65,9 @@ class TestGrafo(unittest.TestCase):
             self.assertTrue(self.g_p.adiciona_aresta('b1', '', 'C'))
         with self.assertRaises(VerticeInvalidoError):
             self.assertTrue(self.g_p.adiciona_aresta('b1', 'A', 'C'))
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('')
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             self.g_p.adiciona_aresta('aa-bb')
         with self.assertRaises(VerticeInvalidoError):
             self.g_p.adiciona_aresta('x', 'J', 'V')

--- a/meu_grafo_teste_builder.py
+++ b/meu_grafo_teste_builder.py
@@ -2,9 +2,7 @@ from bibgrafo.grafo_lista_adj_nao_dir import GrafoListaAdjacenciaNaoDirecionado
 from bibgrafo.grafo_errors import *
 from bibgrafo.aresta import Aresta
 from bibgrafo.vertice import Vertice
-from random import shuffle
-from copy import deepcopy
-from multipledispatch import dispatch
+from functools import singledispatchmethod
 
 class MeuGrafo(GrafoListaAdjacenciaNaoDirecionado):
 
@@ -144,54 +142,8 @@ class MeuGrafo(GrafoListaAdjacenciaNaoDirecionado):
             return arvore_dfs
 
         return dfs_rec(raiz, arvore_dfs)
-
-    @dispatch()
-    def ha_ciclo(self) -> list | bool:
-
-        def dfs_ciclo(V: str, dict_vertices: dict, dict_arestas: dict,
-            lista_vertices: list, lista_arestas: list) -> bool:
-            adj = list(self.arestas_sobre_vertice(V))
-            adj = sorted(adj)
-            for i in adj:
-                a: Aresta = self._arestas[i]
-                if a.rotulo in lista_arestas: continue
-                proximo_vertice = a.v2 if a.v1.rotulo == V else a.v1
-                if proximo_vertice.rotulo in lista_vertices:
-                    dict_arestas[V] = a.rotulo
-                    dict_vertices[V] = proximo_vertice.rotulo
-                    return proximo_vertice.rotulo
-                elif proximo_vertice.rotulo not in lista_vertices:
-                    lista_vertices.append(proximo_vertice.rotulo)
-                    lista_arestas.append(a.rotulo)
-                    dict_arestas[V] = a.rotulo
-                    dict_vertices[V] = proximo_vertice.rotulo
-                    return dfs_ciclo(proximo_vertice.rotulo,
-                    dict_vertices, dict_arestas, lista_vertices, lista_arestas)
-            return False
-
-        for vertice in self._vertices:
-            lista_arestas = {}
-            lista_vertices = {}
-            vertices_percorridos = []
-            arestas_percorridas = []
-            for v in self._vertices:
-                lista_vertices[v.rotulo] = ""
-                lista_arestas[v.rotulo] = ""
-            raiz = dfs_ciclo(vertice.rotulo, lista_vertices,
-            lista_arestas, vertices_percorridos, arestas_percorridas)
-            if raiz:
-                ciclo = [raiz]
-                ciclo.append(lista_arestas[raiz])
-                ciclo.append(lista_vertices[raiz])
-                prox_vertice = lista_vertices[raiz]
-                while not prox_vertice == raiz:
-                    ciclo.append(lista_arestas[prox_vertice])
-                    ciclo.append(lista_vertices[prox_vertice])
-                    prox_vertice = lista_vertices[prox_vertice]
-                return ciclo
-        else: return False
-
-    @dispatch(str)
+    
+    @singledispatchmethod
     def ha_ciclo(self, V='') -> list | bool:
 
         def dfs_ciclo(V: str, raiz: str, dict_vertices: dict, dict_arestas: dict,
@@ -237,6 +189,52 @@ class MeuGrafo(GrafoListaAdjacenciaNaoDirecionado):
                 ciclo.append(lista_vertices[prox_vertice])
                 prox_vertice = lista_vertices[prox_vertice]
             return ciclo
+        else: return False
+
+    @ha_ciclo.register
+    def _(self) -> list | bool:
+
+        def dfs_ciclo(V: str, dict_vertices: dict, dict_arestas: dict,
+            lista_vertices: list, lista_arestas: list) -> bool:
+            adj = list(self.arestas_sobre_vertice(V))
+            adj = sorted(adj)
+            for i in adj:
+                a: Aresta = self._arestas[i]
+                if a.rotulo in lista_arestas: continue
+                proximo_vertice = a.v2 if a.v1.rotulo == V else a.v1
+                if proximo_vertice.rotulo in lista_vertices:
+                    dict_arestas[V] = a.rotulo
+                    dict_vertices[V] = proximo_vertice.rotulo
+                    return proximo_vertice.rotulo
+                elif proximo_vertice.rotulo not in lista_vertices:
+                    lista_vertices.append(proximo_vertice.rotulo)
+                    lista_arestas.append(a.rotulo)
+                    dict_arestas[V] = a.rotulo
+                    dict_vertices[V] = proximo_vertice.rotulo
+                    return dfs_ciclo(proximo_vertice.rotulo,
+                    dict_vertices, dict_arestas, lista_vertices, lista_arestas)
+            return False
+
+        for vertice in self._vertices:
+            lista_arestas = {}
+            lista_vertices = {}
+            vertices_percorridos = []
+            arestas_percorridas = []
+            for v in self._vertices:
+                lista_vertices[v.rotulo] = ""
+                lista_arestas[v.rotulo] = ""
+            raiz = dfs_ciclo(vertice.rotulo, lista_vertices,
+            lista_arestas, vertices_percorridos, arestas_percorridas)
+            if raiz:
+                ciclo = [raiz]
+                ciclo.append(lista_arestas[raiz])
+                ciclo.append(lista_vertices[raiz])
+                prox_vertice = lista_vertices[raiz]
+                while not prox_vertice == raiz:
+                    ciclo.append(lista_arestas[prox_vertice])
+                    ciclo.append(lista_vertices[prox_vertice])
+                    prox_vertice = lista_vertices[prox_vertice]
+                return ciclo
         else: return False
 
     def caminho(self, n: int) -> list:


### PR DESCRIPTION
Nesta nova branch, abordei duas issues:

- a relação de herança entre as Listas de Adjacência (fazendo assim a Lista de Adjacência não-direcionada herdar da sua contraparte direcionada)
- como extra, abordei também diversos métodos repetidos entre as duas (no caso, métodos que estavam repetidos, mas que já eram implementados por herança), o que foi também estendido para as Matrizes de Adjacência → podemos avaliar depois a confecção de uma documentação mais detalhada para cada classe, explicitando assim os métodos herdados
- por último, foi realizada a implementação completa do padrão singledispatch, eliminando assim a necessidade do módulo `multipledispatch`, implementando o padrão desde a herança da classe GrafoIF até as demais classes de grafos